### PR TITLE
Sa 413

### DIFF
--- a/.github/workflows/gradle-branches.yml
+++ b/.github/workflows/gradle-branches.yml
@@ -48,12 +48,19 @@ jobs:
           - web: 'true'
             kafka_consumer: 'false'
             database: 'none'
+            kafka_producer: 'true'
           - web: 'false'
             kafka_consumer: 'true'
             database: 'jpa'
+            kafka_producer: 'true'
           - web: 'true'
             kafka_consumer: 'true'
             database: 'jdbc'
+            kafka_producer: 'true'
+          - web: 'true'
+            kafka_consumer: 'false'
+            database: 'none'
+            kafka_producer: 'false'
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
@@ -76,7 +83,7 @@ jobs:
       - name: Installing dependencies
         run: pip install requests
       - name: Execute python script
-        run: python init.py --web "${{ matrix.web }}" --kafka_consumer "${{ matrix.kafka_consumer }}" --p "my-awesome-app" --n "no.protector.my.awesome.app" --clean "true" --pf "${{ matrix.database }}" --kafka_producer "true"
+        run: python init.py --web "${{ matrix.web }}" --kafka_consumer "${{ matrix.kafka_consumer }}" --p "my-awesome-app" --n "no.protector.my.awesome.app" --clean "true" --pf "${{ matrix.database }}" --kafka_producer "${{ matrix.kafka_producer }}"
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Verify that applicaton still builds

--- a/.github/workflows/gradle-main.yml
+++ b/.github/workflows/gradle-main.yml
@@ -36,6 +36,7 @@ jobs:
         run: ./gradlew build
       - name: System tests
         run: ./gradlew :web-test:test -PsystemTest --info
+      # INITIALIZR:WEB
       - uses: actions/upload-artifact@v2
         with:
           name: web-artifact
@@ -43,6 +44,8 @@ jobs:
             web/build/libs/*
             elasticapm.properties
             Web.Dockerfile
+      # INITIALIZR:WEB
+      # INITIALIZR:KAFKA-CONSUMER
       - uses: actions/upload-artifact@v2
         with:
           name: kafka-artifact
@@ -50,6 +53,7 @@ jobs:
             kafka/build/libs/*
             elasticapm.properties
             Kafka.Dockerfile
+      # INITIALIZR:KAFKA-CONSUMER
 
   # INITIALIZR:WEB
   build_web_image:

--- a/.github/workflows/gradle-main.yml
+++ b/.github/workflows/gradle-main.yml
@@ -167,12 +167,19 @@ jobs:
           - web: 'true'
             kafka_consumer: 'false'
             database: 'none'
+            kafka_producer: 'true'
           - web: 'false'
             kafka_consumer: 'true'
             database: 'jpa'
+            kafka_producer: 'true'
           - web: 'true'
             kafka_consumer: 'true'
             database: 'jdbc'
+            kafka_producer: 'true'
+          - web: 'true'
+            kafka_consumer: 'false'
+            database: 'none'
+            kafka_producer: 'false'
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
@@ -195,7 +202,7 @@ jobs:
       - name: Installing dependencies
         run: pip install requests
       - name: Execute python script
-        run: python init.py --web "${{ matrix.web }}" --kafka_consumer "${{ matrix.kafka_consumer }}" --p "my-awesome-app" --n "no.protector.my.awesome.app" --clean "true" --pf "${{ matrix.database }}" --kafka_producer "true"
+        run: python init.py --web "${{ matrix.web }}" --kafka_consumer "${{ matrix.kafka_consumer }}" --p "my-awesome-app" --n "no.protector.my.awesome.app" --clean "true" --pf "${{ matrix.database }}" --kafka_producer "${{ matrix.kafka_producer }}"
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Verify that applicaton still builds

--- a/init.py
+++ b/init.py
@@ -281,7 +281,7 @@ def should_write_xml(lines_to_write):
 
 
 def remove_between_strings(string, tag):
-    return re.sub(r'%s.*?%s' % (tag, tag), '', string)
+    return re.sub(r'%s.*?%s' % (tag, tag), '', string, flags=re.MULTILINE)
 
 
 def clean_tag_content(tags):

--- a/init.py
+++ b/init.py
@@ -281,7 +281,7 @@ def should_write_xml(lines_to_write):
 
 
 def remove_between_strings(string, tag):
-    return re.sub(r'%s.*?%s' % (tag, tag), '', string, flags=re.MULTILINE)
+    return re.sub(r'*# %s([\S\s]*?)\n *# %s' % (tag, tag), '', string, flags=re.MULTILINE|re.IGNORECASE)
 
 
 def clean_tag_content(tags):
@@ -293,6 +293,8 @@ def clean_tag_content(tags):
         for tag in tags:
             print(f"Removing {tag} from {fpath}")
             content = remove_between_strings(content, tag)
+        if fpath.endswith("gradle-main.yml"):
+            print(f"{content}")
         with open(fpath, "w", encoding="utf-8") as f:
             f.write(content)
 

--- a/init.py
+++ b/init.py
@@ -291,6 +291,7 @@ def clean_tag_content(tags):
         if not content:
             continue
         for tag in tags:
+            print(f"Removing {tag} from {fpath}")
             content = remove_between_strings(content, tag)
         with open(fpath, "w", encoding="utf-8") as f:
             f.write(content)
@@ -409,7 +410,7 @@ set_persistence_framework()
 print("Creating new namespace...")
 create_namespace()
 
-clean_tag_content(tags_to_clean)
+clean_tag_content([f"INITIALIZR:{tag}" for tag in tags_to_clean])
 
 files = get_available_files()
 

--- a/init.py
+++ b/init.py
@@ -355,13 +355,14 @@ def get_files_that_contain_word(word, _files):
 def run_sanity_checks():
     _files = get_available_files()
     files_with_word = get_files_that_contain_word('initializr', _files)
-    name_of_files_with_words = '\n'.join(files_with_word)
     if files_with_word:
-        raise Exception(f"Files contain the word 'Initializr': \n {name_of_files_with_words}")
+        print(f"Found {','.join(files_with_word)} files that contain 'initializr'")
+        raise Exception(f"Files contain the word 'Initializr': \n {','.join(files_with_word)}")
     if not has_kafka_producer and not has_kafka_consumer:
         files_with_word = get_files_that_contain_word('kafka', _files)
         if files_with_word:
-            raise Exception(f"Files contain the word 'kafka': \n {name_of_files_with_words}")
+            print(f"Found {','.join(files_with_word)} files that contain 'kafka'")
+            raise Exception(f"Files contain the word 'kafka': \n {','.join(files_with_word)}")
 
 
 def update_elastic_apm_namespace():

--- a/init.py
+++ b/init.py
@@ -288,6 +288,8 @@ def clean_tag_content(tags):
     _files = get_available_files()
     for fpath in _files:
         content = read(fpath)
+        if not content:
+            continue
         for tag in tags:
             content = remove_between_strings(content, tag)
         with open(fpath, "w", encoding="utf-8") as f:

--- a/init.py
+++ b/init.py
@@ -399,6 +399,7 @@ if clean_initializr:
     tags_to_clean.append("INITIALIZR-DEMO")
 
 if not has_kafka_producer:
+    print("Removing kafka producer")
     tags_to_clean.append("KAFKA-PRODUCER")
 
 print("Updating banner...")

--- a/init.py
+++ b/init.py
@@ -280,36 +280,18 @@ def should_write_xml(lines_to_write):
     return len(lines_that_are_not_initializr_comments) > 1
 
 
+def remove_between_strings(string, tag):
+    return re.sub(r'%s.*?%s' % (tag, tag), '', string)
+
+
 def clean_tag_content(tags):
     _files = get_available_files()
     for fpath in _files:
-        lines = read_lines(fpath)
-        if not lines:
-            continue
+        content = read(fpath)
+        for tag in tags:
+            content = remove_between_strings(content, tag)
         with open(fpath, "w", encoding="utf-8") as f:
-            is_xml = fpath.endswith(".xml")
-            write = True
-            lines_to_write = []
-            last_initializr_comment_line = None
-            for line in lines:
-                if is_one_of_tags_in_initializr_comment(tags, line):
-                    if not last_initializr_comment_line:
-                        last_initializr_comment_line = line
-                    is_same = last_initializr_comment_line.strip() == line.strip()
-                    if not is_same:
-                        continue
-                    last_initializr_comment_line = line
-                    write = not write
-                    continue
-                if write:
-                    lines_to_write.append(line)
-            if is_xml and not should_write_xml(lines_to_write):
-                f.truncate(0)
-                continue
-            if len(lines_to_write) > 0:
-                [f.write(line) for line in lines_to_write]
-            else:
-                f.truncate(0)
+            f.write(content)
 
 
 def clean_initializr_tags():

--- a/init.py
+++ b/init.py
@@ -258,7 +258,7 @@ def get_comment_prefixes():
 
 
 def is_initializr_comment(line):
-    return is_comment_line(line) and "initializr" in line.lower()
+    return is_comment_line(line) and "initializr:" in line.lower()
 
 
 def get_initializer_prefix():


### PR DESCRIPTION
Sorry for the time it has taken to solve this. Just been busy with other stuff.

If you look at this case in gradle-branch.yml, that replicates the issue you ran into:
```
          - web: 'true'
            kafka_consumer: 'false'
            database: 'none'
            kafka_producer: 'false'
```

As long as the pipeline passes then this should be fine :)

Don't mind the big and ugly Python script though. It is a temporary script until we get a proper initializr website or command line tool up and running.