### PR TITLE
SA-419 Upgrade the Initializr to Java 17

### DIFF
--- a/.github/workflows/gradle-branches.yml
+++ b/.github/workflows/gradle-branches.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK 16
         uses: actions/setup-java@v2
         with:
-          java-version: '16'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - name: Build & Unit tests
@@ -67,7 +67,7 @@ jobs:
       - name: Set up JDK 16
         uses: actions/setup-java@v2
         with:
-          java-version: '16'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - uses: actions/cache@v2
@@ -109,7 +109,7 @@ jobs:
       - name: Set up JDK 16
         uses: actions/setup-java@v2
         with:
-          java-version: '16'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - uses: actions/cache@v2
@@ -145,7 +145,7 @@ jobs:
       - name: Set up JDK 16
         uses: actions/setup-java@v2
         with:
-          java-version: '16'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - uses: actions/cache@v2

--- a/.github/workflows/gradle-branches.yml
+++ b/.github/workflows/gradle-branches.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
-      - name: Set up JDK 16
+      - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           java-version: '17'
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
-      - name: Set up JDK 16
+      - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           java-version: '17'
@@ -106,7 +106,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
-      - name: Set up JDK 16
+      - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           java-version: '17'
@@ -142,7 +142,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
-      - name: Set up JDK 16
+      - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           java-version: '17'

--- a/.github/workflows/gradle-main.yml
+++ b/.github/workflows/gradle-main.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
-      - name: Set up JDK 16
+      - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           java-version: '17'
@@ -183,7 +183,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
-      - name: Set up JDK 16
+      - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           java-version: '17'
@@ -225,7 +225,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
-      - name: Set up JDK 16
+      - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           java-version: '17'
@@ -261,7 +261,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
-      - name: Set up JDK 16
+      - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           java-version: '17'

--- a/.github/workflows/gradle-main.yml
+++ b/.github/workflows/gradle-main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up JDK 16
         uses: actions/setup-java@v2
         with:
-          java-version: '16'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - name: Build & Unit tests
@@ -186,7 +186,7 @@ jobs:
       - name: Set up JDK 16
         uses: actions/setup-java@v2
         with:
-          java-version: '16'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - uses: actions/cache@v2
@@ -228,7 +228,7 @@ jobs:
       - name: Set up JDK 16
         uses: actions/setup-java@v2
         with:
-          java-version: '16'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - uses: actions/cache@v2
@@ -264,7 +264,7 @@ jobs:
       - name: Set up JDK 16
         uses: actions/setup-java@v2
         with:
-          java-version: '16'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - uses: actions/cache@v2

--- a/Kafka.Dockerfile
+++ b/Kafka.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:16-buster
+FROM openjdk:17-buster
 COPY /kafka/build/libs/kafka.jar .
 COPY /kafka/build/libs/elastic-apm-agent.jar /elasticapm.properties /
 HEALTHCHECK CMD curl --fail http://localhost:8391/actuator/health || exit 1

--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@
 
 # protector-initializr-java
 
+[comment]: # (INITIALIZR:INITIALIZR-DEMO)
+
 Protector Initializr is a template and project configurator for new Java applications at Protector.
 
 The goal is to provide a sensible and opinionated default on which new systems can be built upon while removing a lot of yak shaving. 
+
+[comment]: # (INITIALIZR:INITIALIZR-DEMO)
 
 ### Build
 
@@ -22,27 +26,6 @@ _Note: systems tests do not execute without the `systemTest` parameter. This is 
 ### Run
 
 Go to Application and run the main method. Intellij should pick it up.
-
-## Operational information
-
-__[TODO]__: Once the system has been put in to production, make sure to
-include information about where to reach the service and other relevant
-information.
-
-* Service name: `protector-initializr`
-* Internal ports: 8080
-* DNS:
-    * __[TODO]__
-* Internal URL:
-    * __[TODO]__
-* External URL:
-    * __[TODO]__
-* Health checks:
-    * Defined in Dockerfile `curl --fail http://localhost:8391/actuator/health || exit 1`
-* Environment variables: `SPRING_PROFILES_ACTIVE=prod`
-* Replicas: 2 or more
-
-[comment]: # (INITIALIZR:INITIALIZR-DEMO)
 
 # Initializr
 
@@ -70,5 +53,26 @@ information.
 ### Documentation
 
 [Documentation can be found here](https://github.com/protectorinsurance/protector-initializr-java/wiki)
+
+[comment]: # (INITIALIZR:INITIALIZR-DEMO)
+
+## Operational information
+
+__[TODO]__: Once the system has been put in to production, make sure to
+include information about where to reach the service and other relevant
+information.
+
+* Service name: `protector-initializr`
+* Internal ports: 8080
+* DNS:
+  * __[TODO]__
+* Internal URL:
+  * __[TODO]__
+* External URL:
+  * __[TODO]__
+* Health checks:
+  * Defined in Dockerfile `curl --fail http://localhost:8391/actuator/health || exit 1`
+* Environment variables: `SPRING_PROFILES_ACTIVE=prod`
+* Replicas: 2 or more
 
 [comment]: # (INITIALIZR:INITIALIZR-DEMO)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ _Note: systems tests do not execute without the `systemTest` parameter. This is 
 
 Go to Application and run the main method. Intellij should pick it up.
 
+[comment]: # (INITIALIZR:INITIALIZR-DEMO)
+
 # Initializr
 
 ![](initializr-script-demo.gif)
@@ -71,8 +73,6 @@ information.
 * External URL:
   * __[TODO]__
 * Health checks:
-  * Defined in Dockerfile `curl --fail http://localhost:8391/actuator/health || exit 1`
+  * Defined in Dockerfile: `curl --fail http://localhost:8391/actuator/health || exit 1`
 * Environment variables: `SPRING_PROFILES_ACTIVE=prod`
 * Replicas: 2 or more
-
-[comment]: # (INITIALIZR:INITIALIZR-DEMO)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Go to Application and run the main method. Intellij should pick it up.
 
 [comment]: # (INITIALIZR:INITIALIZR-DEMO)
 
-## Operational information
+### Operational information
 
 __[TODO]__: Once the system has been put in to production, make sure to
 include information about where to reach the service and other relevant

--- a/Web.Dockerfile
+++ b/Web.Dockerfile
@@ -1,6 +1,5 @@
-FROM azul/zulu-openjdk-alpine:16.0.1 as initializr
-COPY  /web/build/libs/web.jar .
-COPY  /web/build/libs/elastic-apm-agent.jar /elasticapm.properties /
-VOLUME ["/tmp","/var/log/", "/etc/protector/config"]
+FROM openjdk:17-buster
+COPY /web/build/libs/web.jar .
+COPY /web/build/libs/elastic-apm-agent.jar /elasticapm.properties /
 HEALTHCHECK CMD curl --fail http://localhost:8391/actuator/health || exit 1
 ENTRYPOINT ["java","-Xmx4096m","-Dfile.encoding=UTF-8", "-javaagent:/elastic-apm-agent.jar", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/web.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ subprojects {
     apply plugin: 'java-library'
     apply plugin: 'groovy'
 
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 
     dependencyManagement {
         imports {

--- a/build.gradle
+++ b/build.gradle
@@ -21,15 +21,18 @@ allprojects {
         //INITIALIZR:KAFKA-PRODUCER
     }
     apply plugin: 'jacoco'
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
+    }
 }
 
 subprojects {
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'java-library'
     apply plugin: 'groovy'
-
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
 
     dependencyManagement {
         imports {


### PR DESCRIPTION
There is also a minor restructuring of the readme file so that it'll be prettier in both the initializr and when generated.

As for SonarQube:

1. SonarQube still lacks support for Java 16 and gets stuff like `Record` wrong - so if we have to follow SonarQube we would have to be on Java 15 or earlier (I.e. not cool).
2. Since SonarQube doesn't support Java 16 we're not any worse off if we move to 17.
3. I don't think SonarQube should get to dictate what language version we use. Sure, there are technologies that get to dictate: IDE, Gradle, Spring, etc, but no SonarQube. If this is a problem then we should find a replacement that can keep up. 