### PR TITLE
Sa 424

### DIFF
--- a/init.py
+++ b/init.py
@@ -449,12 +449,6 @@ clean_tag_content(tags_to_clean)
 
 files = get_available_files()
 
-if not has_web:
-    find_and_replace_in_files(['needs: [build_web_image, build_kafka_image]'], 'needs: build_kafka_image', files)
-
-if not has_kafka_consumer:
-    find_and_replace_in_files(['needs: [build_web_image, build_kafka_image]'], 'needs: build_web_image', files)
-
 print("Replacing references to initializr...")
 find_and_replace_in_files(["protector-initializr-java", "protector-initializr"], project_name.lower(), files)
 find_and_replace_in_files(["no.protector.initializr"], namespace, files)
@@ -473,6 +467,12 @@ underscore_project_name = project_name.replace('-', '_')
 find_and_replace_in_files(["initializr_kafka_client"], f"{underscore_project_name}_kafka_client", files)
 
 find_and_replace_in_files(["initializr"], project_name.lower(), ["Web.Dockerfile", "Kafka.Dockerfile"])
+
+if has_web and not has_kafka_consumer:
+    find_and_replace_in_files(["\\[ build_web_image, build_async_image \\]"], "build_web_image", files)
+
+if has_kafka_consumer and not has_web:
+    find_and_replace_in_files(["\\[ build_web_image, build_async_image \\]"], "build_async_image", files)
 
 group = f"{namespace.split('.')[0]}.{namespace.split('.')[1]}"
 find_and_replace_in_files(["group = 'no.protector'"], f"group = '{group}'", ["build.gradle"])

--- a/init.py
+++ b/init.py
@@ -257,7 +257,7 @@ def remove_unused_imports():
 
 
 def get_comment_prefixes():
-    return ["//", "-- ", "<!-- ", "# ", "[comment]: # ("]
+    return ["//", "--", "<!--", '# ', "[comment]: # (", "*", '/*']
 
 
 def is_initializr_comment(line):
@@ -347,7 +347,7 @@ def clean_all_double_empty_lines():
 
 
 def is_comment_line(line):
-    comment_symbols = ['*', "#", '//', '/*']
+    comment_symbols = get_comment_prefixes()
     return any(comment_symbol in line for comment_symbol in comment_symbols)
 
 

--- a/kafka/build.gradle
+++ b/kafka/build.gradle
@@ -9,6 +9,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation "org.springframework.boot:spring-boot-starter-actuator"
     implementation 'org.springframework.kafka:spring-kafka'
+    //INITIALIZR:DATABASE
+    implementation 'org.flywaydb:flyway-core'
+    //INITIALIZR:DATABASE
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -11,6 +11,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-actuator"
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.apache.commons:commons-lang3'
+    //INITIALIZR:DATABASE
+    implementation 'org.flywaydb:flyway-core'
+    //INITIALIZR:DATABASE
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 


### PR DESCRIPTION
### Changes:

#### 1. Workflow jobs that depends on both kafka and web should change when just kafka or web is picked

In for example `gradle-main.yml` we have these lines to deploy to test:

```yml
  deploy_test:
    name: Deploy to test
    if: ${{ false }} # TODO: Delete me when application is set up in ICP
    runs-on: self-hosted
    needs: [ build_web_image, build_async_image ]
```

Before the `needs` part did not change, even if the `build_async_image ` step was deleted.  Now, after running the `init.py` script and only  picking "web" we end up with the following:

```yml
  deploy_test:
    name: Deploy to test
    if: ${{ false }} # TODO: Delete me when application is set up in ICP
    runs-on: self-hosted
    needs: build_web_image
```

#### 2. Adding Flyway to both Kafka and Web modules

This is so that the application can trigger Flyway and run schema validation and migrations automatically.

