### PR TITLE
SA-556 Standardize build

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   deploy_prod:
     name: Deploy to prod
-    runs-on: [self-hosted, prod]
+    runs-on: [ self-hosted, prod ]
     steps:
       # INITIALIZR:WEB
       - name: Deploy web to prod

--- a/.github/workflows/gradle-branches.yml
+++ b/.github/workflows/gradle-branches.yml
@@ -15,17 +15,17 @@ jobs:
         with:
           fetch-depth: 0
       - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
+          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
-      - uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
-          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - name: Build & Unit tests
         run: ./gradlew build
       - name: System tests
@@ -73,6 +73,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
+          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -94,8 +99,6 @@ jobs:
         run: pip install requests
       - name: Execute python script
         run: python init.py --web "${{ matrix.web }}" --kafka_consumer "${{ matrix.kafka_consumer }}" --p "my-awesome-app" --n "no.protector.my.awesome.app" --clean "true" --pf "${{ matrix.database }}" --kafka_producer "${{ matrix.kafka_producer }}"
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Verify that applicaton still builds
         run: ./gradlew build -PsystemTest --info
 
@@ -116,6 +119,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
+          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -137,8 +145,6 @@ jobs:
         run: pip install requests
       - name: Execute python script
         run: python init.py --web "${{ matrix.web }}" --kafka_consumer "${{ matrix.kafka_consumer }}" --p "my-awesome-app" --n "no.protector.my.awesome.app" --clean "false" --pf "jdbc" --kafka_producer "true"
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Verify that applicaton still builds
         run: ./gradlew build -PsystemTest --info
 
@@ -153,6 +159,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
+          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -174,8 +185,6 @@ jobs:
         run: pip install requests
       - name: Execute python script
         run: python init.py --web "true" --kafka_consumer "true" --p "my-awesome-app" --n "no.protector.my.awesome.app" --clean "false" --pf "${{ matrix.database }}" --kafka_producer "true"
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Verify that applicaton still builds
         run: ./gradlew build -PsystemTest --info
 

--- a/.github/workflows/gradle-branches.yml
+++ b/.github/workflows/gradle-branches.yml
@@ -21,6 +21,11 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
+          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - name: Build & Unit tests
         run: ./gradlew build
       - name: System tests

--- a/.github/workflows/gradle-main.yml
+++ b/.github/workflows/gradle-main.yml
@@ -29,17 +29,17 @@ jobs:
         with:
           fetch-depth: 0
       - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
+          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
-      - uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
-          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - name: Build & Unit tests
         run: ./gradlew build
       - name: System tests
@@ -191,6 +191,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
+          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -212,8 +217,6 @@ jobs:
         run: pip install requests
       - name: Execute python script
         run: python init.py --web "${{ matrix.web }}" --kafka_consumer "${{ matrix.kafka_consumer }}" --p "my-awesome-app" --n "no.protector.my.awesome.app" --clean "true" --pf "${{ matrix.database }}" --kafka_producer "${{ matrix.kafka_producer }}"
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Verify that applicaton still builds
         run: ./gradlew build -PsystemTest --info
 
@@ -233,6 +236,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
+          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -254,8 +262,6 @@ jobs:
         run: pip install requests
       - name: Execute python script
         run: python init.py --web "${{ matrix.web }}" --kafka_consumer "${{ matrix.kafka_consumer }}" --p "my-awesome-app" --n "no.protector.my.awesome.app" --clean "false" --pf "jdbc" --kafka_producer "true"
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Verify that applicaton still builds
         run: ./gradlew build -PsystemTest --info
 
@@ -269,6 +275,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
+          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -290,8 +301,6 @@ jobs:
         run: pip install requests
       - name: Execute python script
         run: python init.py --web "true" --kafka_consumer "true" --p "my-awesome-app" --n "no.protector.my.awesome.app" --clean "false" --pf "${{ matrix.database }}" --kafka_producer "true"
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Verify that applicaton still builds
         run: ./gradlew build -PsystemTest --info
   # INITIALIZR:INITIALIZR-DEMO

--- a/.github/workflows/gradle-main.yml
+++ b/.github/workflows/gradle-main.yml
@@ -35,6 +35,11 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
+          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - name: Build & Unit tests
         run: ./gradlew build
       - name: System tests

--- a/.github/workflows/gradle-main.yml
+++ b/.github/workflows/gradle-main.yml
@@ -70,8 +70,8 @@ jobs:
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
+          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - uses: docker/build-push-action@v3
         with:
           file: Web.Dockerfile
@@ -96,8 +96,8 @@ jobs:
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.PROTECTOR_GITHUB_MACHINE_USER }}
+          password: ${{ secrets.PROTECTOR_GITHUB_MACHINE_TOKEN }}
       - uses: docker/build-push-action@v3
         with:
           file: Kafka.Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ modules.xml
 
 # Sonarlint plugin
 .idea/sonarlint
+
+# Visual Studio Code
+.vscode/
+bin/

--- a/Kafka.Dockerfile
+++ b/Kafka.Dockerfile
@@ -1,5 +1,5 @@
-FROM eclipse-temurin:17
-COPY /kafka/build/libs/kafka.jar .
+FROM ghcr.io/protectorinsurance/protector-java-17:latest
+COPY /kafka/build/libs/kafka.jar /
 COPY /kafka/build/libs/elastic-apm-agent.jar /elasticapm.properties /
 HEALTHCHECK CMD curl --fail http://localhost:8391/actuator/health || exit 1
-ENTRYPOINT ["java","-Xmx4096m","-Dfile.encoding=UTF-8", "-javaagent:/elastic-apm-agent.jar", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/kafka.jar"]
+ENTRYPOINT ["java", "-Xmx4096m", "-Dfile.encoding=UTF-8", "-javaagent:/elastic-apm-agent.jar", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/kafka.jar"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The goal is to provide a sensible and opinionated default on which new systems c
 
 **Build with system tests**: (Requires Docker)  
 `gradlew clean build -PsystemTest`  
-_Note: systems tests do not execute without the `systemTest` parameter. This is done to cut down on build time_
+_Note 1: System tests do not execute without the `systemTest` parameter. This is done to cut down on build time._  
+_Note 2: Before running system tests you must log in to ghcr.io using `docker login ghcr.io` with a valid authentication token. [More details can be found here](https://github.com/protectorinsurance/protector-initializr-java/wiki/Docker-authentication)._
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ The goal is to provide a sensible and opinionated default on which new systems c
 ### Build
 
 **Normal Build**:  
-`gradle clean build`
+`gradlew clean build`
 
 **Build with system tests**: (Requires Docker)  
-`gradle clean build -PsystemTest`  
+`gradlew clean build -PsystemTest`  
 _Note: systems tests do not execute without the `systemTest` parameter. This is done to cut down on build time_
 
 ### Run

--- a/Web.Dockerfile
+++ b/Web.Dockerfile
@@ -1,5 +1,5 @@
-FROM eclipse-temurin:17
-COPY /web/build/libs/web.jar .
+FROM ghcr.io/protectorinsurance/protector-java-17:latest
+COPY /web/build/libs/web.jar /
 COPY /web/build/libs/elastic-apm-agent.jar /elasticapm.properties /
 HEALTHCHECK CMD curl --fail http://localhost:8391/actuator/health || exit 1
-ENTRYPOINT ["java","-Xmx4096m","-Dfile.encoding=UTF-8", "-javaagent:/elastic-apm-agent.jar", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/web.jar"]
+ENTRYPOINT ["java", "-Xmx4096m", "-Dfile.encoding=UTF-8", "-javaagent:/elastic-apm-agent.jar", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/web.jar"]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Use Protector base image for Java (makes the application ready for using database with encryption)
- Gradle cleanup
- Some additional ignores for VSCode files