### PR TITLE
SA-556 Upgrade to Spring Boot 2.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'groovy'
-    id 'org.springframework.boot' version '2.6.7'
+    id 'org.springframework.boot' version '2.7.0'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id "org.sonarqube" version "3.4.0.2513"
 }
@@ -36,7 +36,7 @@ subprojects {
 
     dependencyManagement {
         imports {
-            mavenBom "org.springframework.boot:spring-boot-dependencies:2.6.7"
+            mavenBom "org.springframework.boot:spring-boot-dependencies:2.7.0"
         }
     }
 

--- a/domain-jpa/build.gradle
+++ b/domain-jpa/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     //INITIALIZR:KAFKA-PRODUCER
     implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-sqlserver'
     runtimeOnly "com.microsoft.sqlserver:mssql-jdbc"
 
     //INITIALIZR:KAFKA-PRODUCER

--- a/domain-jpa/src/main/java/no/protector/initializr/domain/configuration/secret/DbSecret.java
+++ b/domain-jpa/src/main/java/no/protector/initializr/domain/configuration/secret/DbSecret.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.PropertySource;
 @Primary
 @Configuration
 @ConfigurationProperties(prefix = "db")
-@PropertySource(value = "file:/var/run/secrets/db_write", ignoreResourceNotFound = true)
+@PropertySource(value = "file:/run/secrets/db_write", ignoreResourceNotFound = true)
 @PropertySource(value = "classpath:secrets/db_write.properties", ignoreResourceNotFound = true)
 public class DbSecret {
     private String hostPort;

--- a/domain-jpa/src/main/java/no/protector/initializr/domain/configuration/secret/KafkaSecret.java
+++ b/domain-jpa/src/main/java/no/protector/initializr/domain/configuration/secret/KafkaSecret.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@PropertySource(value = "file:/var/run/secrets/initializr_kafka_client", ignoreResourceNotFound = true)
+@PropertySource(value = "file:/run/secrets/initializr_kafka_client", ignoreResourceNotFound = true)
 @PropertySource(value = "classpath:/secrets/initializr_kafka_client", ignoreResourceNotFound = true)
 public class KafkaSecret {
 

--- a/domain-no-database/src/main/java/no/protector/initializr/domain/configuration/secret/KafkaSecret.java
+++ b/domain-no-database/src/main/java/no/protector/initializr/domain/configuration/secret/KafkaSecret.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@PropertySource(value = "file:/var/run/secrets/initializr_kafka_client", ignoreResourceNotFound = true)
+@PropertySource(value = "file:/run/secrets/initializr_kafka_client", ignoreResourceNotFound = true)
 @PropertySource(value = "classpath:/secrets/initializr_kafka_client", ignoreResourceNotFound = true)
 public class KafkaSecret {
 

--- a/domain/src/main/java/no/protector/initializr/domain/configuration/secret/DbSecret.java
+++ b/domain/src/main/java/no/protector/initializr/domain/configuration/secret/DbSecret.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.PropertySource;
 @Primary
 @Configuration
 @ConfigurationProperties(prefix = "db")
-@PropertySource(value = "file:/var/run/secrets/db_write", ignoreResourceNotFound = true)
+@PropertySource(value = "file:/run/secrets/db_write", ignoreResourceNotFound = true)
 @PropertySource(value = "classpath:secrets/db_write.properties", ignoreResourceNotFound = true)
 public class DbSecret {
     private String hostPort;

--- a/domain/src/main/java/no/protector/initializr/domain/configuration/secret/KafkaSecret.java
+++ b/domain/src/main/java/no/protector/initializr/domain/configuration/secret/KafkaSecret.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@PropertySource(value = "file:/var/run/secrets/initializr_kafka_client", ignoreResourceNotFound = true)
+@PropertySource(value = "file:/run/secrets/initializr_kafka_client", ignoreResourceNotFound = true)
 @PropertySource(value = "classpath:/secrets/initializr_kafka_client", ignoreResourceNotFound = true)
 public class KafkaSecret {
 

--- a/kafka-test/build.gradle
+++ b/kafka-test/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     //INITIALIZR:DATABASE
     testImplementation 'org.flywaydb:flyway-core'
+    testImplementation 'org.flywaydb:flyway-sqlserver'
     runtimeOnly "com.microsoft.sqlserver:mssql-jdbc"
     //INITIALIZR:DATABASE
 

--- a/kafka-test/src/test/groovy/no/protector/initializr/system/test/config/ContainerConfig.groovy
+++ b/kafka-test/src/test/groovy/no/protector/initializr/system/test/config/ContainerConfig.groovy
@@ -127,7 +127,7 @@ class ContainerConfig {
         //INITIALIZR:DATABASE
                 .withCopyFileToContainer(
                         MountableFile.forClasspathResource("db_write.properties"),
-                        "/var/run/secrets/db_write")
+                        "/run/secrets/db_write")
         //INITIALIZR:DATABASE
     }
 

--- a/kafka/build.gradle
+++ b/kafka/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     //INITIALIZR:DATABASE
     implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-sqlserver'
     //INITIALIZR:DATABASE
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/kafka/src/main/java/no/protector/initializr/kafka/config/secret/KafkaConsumerSecret.java
+++ b/kafka/src/main/java/no/protector/initializr/kafka/config/secret/KafkaConsumerSecret.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@PropertySource(value = "file:/var/run/secrets/initializr_kafka_client", ignoreResourceNotFound = true)
+@PropertySource(value = "file:/run/secrets/initializr_kafka_client", ignoreResourceNotFound = true)
 @PropertySource(value = "classpath:/secrets/initializr_kafka_client", ignoreResourceNotFound = true)
 public class KafkaConsumerSecret {
     private String username;

--- a/kafka/src/main/resources/application-system-test.yml
+++ b/kafka/src/main/resources/application-system-test.yml
@@ -2,6 +2,10 @@ integration:
   userServiceUrl: http://mockserver:1080
 
 spring:
+  # INITIALIZR:DATABASE
+  datasource:
+    url: jdbc:sqlserver://${db.host_port};databaseName=${db.database_name};applicationName=${spring.application.name};sendStringParametersAsUnicode=false;lockTimeout=15000;encrypt=false
+  # INITIALIZR:DATABASE
   kafka:
     properties:
       sasl:

--- a/web-test/build.gradle
+++ b/web-test/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     //INITIALIZR:KAFKA-PRODUCER
     //INITIALIZR:DATABASE
     testImplementation 'org.flywaydb:flyway-core'
+    testImplementation 'org.flywaydb:flyway-sqlserver'
     runtimeOnly "com.microsoft.sqlserver:mssql-jdbc"
     //INITIALIZR:DATABASE
 

--- a/web-test/src/test/groovy/no/protector/initializr/system/test/config/ContainerConfig.groovy
+++ b/web-test/src/test/groovy/no/protector/initializr/system/test/config/ContainerConfig.groovy
@@ -137,7 +137,7 @@ class ContainerConfig {
         //INITIALIZR:DATABASE
                 .withCopyFileToContainer(
                         MountableFile.forClasspathResource("db_write.properties"),
-                        "/var/run/secrets/db_write")
+                        "/run/secrets/db_write")
         //INITIALIZR:DATABASE
     }
 

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3'
     //INITIALIZR:DATABASE
     implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-sqlserver'
     //INITIALIZR:DATABASE
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/web/src/main/resources/application-system-test.yml
+++ b/web/src/main/resources/application-system-test.yml
@@ -1,8 +1,12 @@
 integration:
   userServiceUrl: http://mockserver:1080
 
-# INITIALIZR:KAFKA-PRODUCER
 spring:
+  # INITIALIZR:DATABASE
+  datasource:
+    url: jdbc:sqlserver://${db.host_port};databaseName=${db.database_name};applicationName=${spring.application.name};sendStringParametersAsUnicode=false;lockTimeout=15000;encrypt=false
+  # INITIALIZR:DATABASE
+  # INITIALIZR:KAFKA-PRODUCER
   kafka:
     properties:
       sasl:
@@ -10,7 +14,9 @@ spring:
         jaas.config:
       security:
         protocol: PLAINTEXT
+  # INITIALIZR:KAFKA-PRODUCER
 
+# INITIALIZR:KAFKA-PRODUCER
 kafka:
   bootstrap-servers: "kafka:9092"
   schema-registry-url: http://schema-registry:8081


### PR DESCRIPTION
- Adding sqlserver module for flyway which must be explicitly included since flyway 8
- Disabling database encryption when running system tests
- Changing to the official mount point for secrets (this is not essential but it conforms better to the Docker documentation)